### PR TITLE
Cross-thread actions may cause race condition

### DIFF
--- a/AdvancedVehicleOptions/AdvancedVehicleOptions.cs
+++ b/AdvancedVehicleOptions/AdvancedVehicleOptions.cs
@@ -373,8 +373,8 @@ namespace AdvancedVehicleOptionsUID
             DefaultOptions.CheckForConflicts();
 
             // Update existing vehicles
-            new EnumerableActionThread(VehicleOptions.UpdateCapacityUnits);
-            new EnumerableActionThread(VehicleOptions.UpdateBackEngines);
+            SimulationManager.instance.AddAction(VehicleOptions.UpdateCapacityUnits);
+            SimulationManager.instance.AddAction(VehicleOptions.UpdateBackEngines);
 
             DebugUtils.Log("Configuration initialized");
             LogVehicleListSteamID();
@@ -417,8 +417,8 @@ namespace AdvancedVehicleOptionsUID
             DefaultOptions.CheckForConflicts();
 
             // Update existing vehicles
-            new EnumerableActionThread(VehicleOptions.UpdateCapacityUnits);
-            new EnumerableActionThread(VehicleOptions.UpdateBackEngines);
+            SimulationManager.instance.AddAction(VehicleOptions.UpdateCapacityUnits);
+            SimulationManager.instance.AddAction(VehicleOptions.UpdateBackEngines);
 
             DebugUtils.Log("Configuration imported");
             LogVehicleListSteamID();
@@ -430,8 +430,8 @@ namespace AdvancedVehicleOptionsUID
             DefaultOptions.CheckForConflicts();
 
             // Update existing vehicles
-            new EnumerableActionThread(VehicleOptions.UpdateCapacityUnits);
-            new EnumerableActionThread(VehicleOptions.UpdateBackEngines);
+            SimulationManager.instance.AddAction(VehicleOptions.UpdateCapacityUnits);
+            SimulationManager.instance.AddAction(VehicleOptions.UpdateBackEngines);
 
             DebugUtils.Log("Configuration reset");
         }
@@ -489,27 +489,27 @@ namespace AdvancedVehicleOptionsUID
             {
                 if(options == null)
                 {
-                    new EnumerableActionThread(ActionRemoveParkedAll);
+                    SimulationManager.instance.AddAction(ActionRemoveParkedAll);
                     return;
                 }
                 
                 m_removeParkedInfo = options.prefab;
-                new EnumerableActionThread(ActionRemoveParked);
+                SimulationManager.instance.AddAction(ActionRemoveParked);
             }
             else
             {
                 if (options == null)
                 {
-                    new EnumerableActionThread(ActionRemoveExistingAll);
+                    SimulationManager.instance.AddAction(ActionRemoveExistingAll);
                     return;
                 }
 
                 m_removeInfo = options.prefab;
-                new EnumerableActionThread(ActionRemoveExisting);
+                SimulationManager.instance.AddAction(ActionRemoveExisting);
             }
         }
 
-        public static IEnumerator ActionRemoveExisting(ThreadBase t)
+        public static void ActionRemoveExisting()
         {
             VehicleInfo info = m_removeInfo;
             Array16<Vehicle> vehicles = VehicleManager.instance.m_vehicles;
@@ -521,12 +521,10 @@ namespace AdvancedVehicleOptionsUID
                     if (info == vehicles.m_buffer[i].Info)
                         VehicleManager.instance.ReleaseVehicle(i);
                 }
-
-                if (i % 256 == 255) yield return i;
             }
         }
 
-        public static IEnumerator ActionRemoveParked(ThreadBase t)
+        public static void ActionRemoveParked()
         {
             VehicleInfo info = m_removeParkedInfo;
             Array16<VehicleParked> parkedVehicles = VehicleManager.instance.m_parkedVehicles;
@@ -538,26 +536,22 @@ namespace AdvancedVehicleOptionsUID
                     if (info == parkedVehicles.m_buffer[i].Info)
                         VehicleManager.instance.ReleaseParkedVehicle(i);
                 }
-
-                if (i % 256 == 255) yield return i;
             }
         }
 
-        public static IEnumerator ActionRemoveExistingAll(ThreadBase t)
+        public static void ActionRemoveExistingAll()
         {
             for (ushort i = 0; i < VehicleManager.instance.m_vehicles.m_buffer.Length; i++)
             {
                 VehicleManager.instance.ReleaseVehicle(i);
-                if (i % 256 == 255) yield return i;
             }
         }
 
-        public static IEnumerator ActionRemoveParkedAll(ThreadBase t)
+        public static void ActionRemoveParkedAll()
         {
             for (ushort i = 0; i < VehicleManager.instance.m_parkedVehicles.m_buffer.Length; i++)
             {
                 VehicleManager.instance.ReleaseParkedVehicle(i);
-                if (i % 256 == 255) yield return i;
             }
         }
 

--- a/AdvancedVehicleOptions/GUI/UIOptionPanel.cs
+++ b/AdvancedVehicleOptions/GUI/UIOptionPanel.cs
@@ -566,8 +566,8 @@ namespace AdvancedVehicleOptionsUID.GUI
 
                 VehicleOptions.prefabUpdateEngine = m_options.prefab;
                 VehicleOptions.prefabUpdateUnits = m_options.prefab;
-                new EnumerableActionThread(VehicleOptions.UpdateBackEngines);
-                new EnumerableActionThread(VehicleOptions.UpdateCapacityUnits);
+                SimulationManager.instance.AddAction(VehicleOptions.UpdateBackEngines);
+                SimulationManager.instance.AddAction(VehicleOptions.UpdateCapacityUnits);
 
                 Show(m_options);
 
@@ -623,7 +623,7 @@ namespace AdvancedVehicleOptionsUID.GUI
                 if (m_options.addBackEngine == state)
                 {
                     VehicleOptions.prefabUpdateEngine = m_options.prefab;
-                    new EnumerableActionThread(VehicleOptions.UpdateBackEngines);
+                    SimulationManager.instance.AddAction(VehicleOptions.UpdateBackEngines);
                 }
             }
             else if (component == m_useColors && m_options.useColorVariations != state)
@@ -731,7 +731,7 @@ namespace AdvancedVehicleOptionsUID.GUI
 
             m_options.capacity = int.Parse(text);
             VehicleOptions.prefabUpdateUnits = m_options.prefab;
-            new EnumerableActionThread(VehicleOptions.UpdateCapacityUnits);
+            SimulationManager.instance.AddAction(VehicleOptions.UpdateCapacityUnits);
 
             m_initialized = true;
         }
@@ -743,7 +743,7 @@ namespace AdvancedVehicleOptionsUID.GUI
 
             m_options.specialcapacity = int.Parse(text);
             VehicleOptions.prefabUpdateUnits = m_options.prefab;
-            new EnumerableActionThread(VehicleOptions.UpdateCapacityUnits);
+            SimulationManager.instance.AddAction(VehicleOptions.UpdateCapacityUnits);
 
             m_initialized = true;
         }

--- a/AdvancedVehicleOptions/VehicleOptions.cs
+++ b/AdvancedVehicleOptions/VehicleOptions.cs
@@ -1047,7 +1047,7 @@ namespace AdvancedVehicleOptionsUID
             return count;
         }
 
-        public static IEnumerator UpdateCapacityUnits(ThreadBase t)
+        public static void UpdateCapacityUnits()
         {
             int count = 0;
             Array16<Vehicle> vehicles = VehicleManager.instance.m_vehicles;
@@ -1097,7 +1097,6 @@ namespace AdvancedVehicleOptionsUID
                         }
                     }
                 }
-                if (i % 256 == 255) yield return null;
             }
             prefabUpdateUnits = null;
 
@@ -1107,7 +1106,7 @@ namespace AdvancedVehicleOptionsUID
             }
         }
 
-        public static IEnumerator UpdateBackEngines(ThreadBase t)
+        public static void UpdateBackEngines()
         {
             Array16<Vehicle> vehicles = VehicleManager.instance.m_vehicles;
             for (uint i = 0; i < vehicles.m_buffer.Length; i++)
@@ -1141,7 +1140,6 @@ namespace AdvancedVehicleOptionsUID
                     DebugUtils.Log("Couldn't update back engine :");
                     Debug.LogError(e);
                 }
-                if (i % 256 == 255) yield return null;
             }
 
             prefabUpdateEngine = null;


### PR DESCRIPTION
I think the repository is missing one change according to workshop changelog but I decided to create PR anyways.

Changes:
---
- Replaced `EnumerableActionThread` with `SimulationManager.Action` to prevent race conditions.

More info about the problem it fixes
---

`EnumerableActionThread` creates brand new worker thread and since your actions are neither of type `Task` or `ContextSwitch` they will be processed without synchronization, so your code: 
```cs
new EnumerableActionThread(VehicleOptions.UpdateCapacityUnits);
```
is an equivalent to this code _(under the hood)_
```cs
Thread newThread = new Thread(() => {
   var enumerator = VehicleOptions.UpdateCapacityUnits(null);
   for(;;) {
      if (!enumerator.MoveNext()) {
        return;
      }
    }
});
newThread.Start();
```
Modifying any Simulation data will result in data corruption sooner or later.
Here you can find perfect example of data corruption(reported few days ago in the thread for AVO bug/error reports):
https://steamcommunity.com/workshop/filedetails/discussion/1548831935/2152098843852941643/?ctp=3#c4328514571303298153

The other variant of `Invalid list detected!` error reveal yourself in form of ghost vehicles -> cannot be removed, will block the traffic.

![unknown](https://user-images.githubusercontent.com/19638970/138189535-b4dfd148-0747-4282-8638-74d43eeef01d.png)

Your code is also modifying `CitizenUnits`, so there is a possibility for creating sort of a memory leak when race condition occur (e.g. simulation won't see released `CitizenUnits` so.. the game will run out of them at some point in the future causing city collapse because citizens could not use private cars or public transport vehicles - those units "hold" `Citizen` while vehicle is moving, no units, no movement, empty streets).

Other concerns:
---
I'll explain in the code below 😉 
